### PR TITLE
Add kubeconfig option and detailed expiry output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # cert-tls-check
+
+A small utility that scans Kubernetes TLS secrets and webhook configurations for
+certificates and reports how many days remain until they expire. By default it
+runs inside the cluster but you can provide a kubeconfig for local debugging.
+
+## Usage
+
+```bash
+go run main.go --kubeconfig=/path/to/kubeconfig
+```
+
+The tool prints `INFO` lines for certificates that are still valid, `ALERT` when
+a certificate is within the threshold (30 days by default), and `EXPIRED` for
+any that are already expired.

--- a/client/kubernetes_client_init.go
+++ b/client/kubernetes_client_init.go
@@ -2,16 +2,38 @@ package client
 
 import (
 	"fmt"
+	"os"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
-func InitK8SClient() (*kubernetes.Clientset, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load in-cluster config: %v", err)
+// InitK8SClient creates a Kubernetes clientset. If kubeconfigPath is provided it
+// will be used to build a config, otherwise in-cluster config is attempted.
+func InitK8SClient(kubeconfigPath string) (*kubernetes.Clientset, error) {
+	var (
+		config *rest.Config
+		err    error
+	)
+
+	if kubeconfigPath != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load kubeconfig from %s: %v", kubeconfigPath, err)
+		}
+	} else if env := os.Getenv("KUBECONFIG"); env != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", env)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load kubeconfig from %s: %v", env, err)
+		}
+	} else {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load in-cluster config: %v", err)
+		}
 	}
+
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kubernetes client: %v", err)


### PR DESCRIPTION
## Summary
- allow providing a kubeconfig path via `--kubeconfig`
- create client with kubeconfig or fallback to in-cluster config
- print INFO/ALERT/EXPIRED with remaining days for all certs
- document usage and new output in README

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6879f7c16b608326b8629696c6b43642