### PR TITLE
Add kubeconfig flag for local debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ A small utility that scans Kubernetes secrets and webhook configurations for TLS
 certificates that are nearing expiration. It runs inside a cluster and prints
 warnings for any certificates expiring within the configured threshold (30 days
 by default).
+
+When running outside of a cluster you can provide a kubeconfig file for local
+debugging:
+
+```bash
+go run main.go --kubeconfig=/path/to/config
+```

--- a/client/kubernetes_client_init.go
+++ b/client/kubernetes_client_init.go
@@ -1,20 +1,37 @@
 package client
 
 import (
-	"fmt"
+        "fmt"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+        "k8s.io/client-go/kubernetes"
+        "k8s.io/client-go/rest"
+        "k8s.io/client-go/tools/clientcmd"
 )
 
-func InitK8SClient() (*kubernetes.Clientset, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load in-cluster config: %v", err)
-	}
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes client: %v", err)
-	}
-	return clientset, nil
+// InitK8SClient initializes a Kubernetes client. When kubeconfigPath is not
+// empty it will be used to create an out-of-cluster client. Otherwise it falls
+// back to the in-cluster configuration.
+func InitK8SClient(kubeconfigPath string) (*kubernetes.Clientset, error) {
+        var (
+                config *rest.Config
+                err    error
+        )
+
+        if kubeconfigPath != "" {
+                config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+                if err != nil {
+                        return nil, fmt.Errorf("failed to load kubeconfig: %v", err)
+                }
+        } else {
+                config, err = rest.InClusterConfig()
+                if err != nil {
+                        return nil, fmt.Errorf("failed to load in-cluster config: %v", err)
+                }
+        }
+
+        clientset, err := kubernetes.NewForConfig(config)
+        if err != nil {
+                return nil, fmt.Errorf("failed to create Kubernetes client: %v", err)
+        }
+        return clientset, nil
 }

--- a/main.go
+++ b/main.go
@@ -1,36 +1,38 @@
 package main
 
 import (
-	"log"
-	"time"
-	"time-tls-checker/cert"
-	"time-tls-checker/client"
+        "flag"
+        "log"
+        "time"
+        "time-tls-checker/cert"
+        "time-tls-checker/client"
 )
 
 func main() {
-	// 初始化 Kubernetes 客户端
-	clientset, err := client.InitK8SClient()
-	if err != nil {
-		log.Fatalf("Failed to init Kubernetes client: %v", err)
-	}
+        kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig for local debugging")
+        alertThreshold := flag.Int("alert-threshold", 30, "Days before expiry to warn")
+        flag.Parse()
 
-	// 设置提前告警的天数
-	alertThreshold := 30
+        // 初始化 Kubernetes 客户端
+        clientset, err := client.InitK8SClient(*kubeconfig)
+        if err != nil {
+                log.Fatalf("Failed to init Kubernetes client: %v", err)
+        }
 
 	// 定时检查逻辑
 	ticker := time.NewTicker(24 * time.Hour)
 	defer ticker.Stop()
 
 	// 立即执行一次
-	cert.CheckAllNamespaces(clientset, alertThreshold)
-	cert.CheckMutatingWebhookCABundles(clientset, alertThreshold)
+        cert.CheckAllNamespaces(clientset, *alertThreshold)
+        cert.CheckMutatingWebhookCABundles(clientset, *alertThreshold)
 
 	// 循环检查
 	for {
 		select {
 		case <-ticker.C:
-			cert.CheckAllNamespaces(clientset, alertThreshold)
-			cert.CheckMutatingWebhookCABundles(clientset, alertThreshold)
+                        cert.CheckAllNamespaces(clientset, *alertThreshold)
+                        cert.CheckMutatingWebhookCABundles(clientset, *alertThreshold)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- support specifying a kubeconfig for out-of-cluster runs
- document local debugging via `--kubeconfig`

## Testing
- `go build ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687a09e57a908326891c7609149ac330