### PR TITLE
Expose basic metrics endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,38 +1,47 @@
 package main
 
 import (
-        "flag"
-        "log"
-        "time"
-        "time-tls-checker/cert"
-        "time-tls-checker/client"
+	"flag"
+	"log"
+	"time"
+	"time-tls-checker/cert"
+	"time-tls-checker/client"
+	"time-tls-checker/metrics"
 )
 
 func main() {
-        kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig for local debugging")
-        alertThreshold := flag.Int("alert-threshold", 30, "Days before expiry to warn")
-        flag.Parse()
+	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig for local debugging")
+	alertThreshold := flag.Int("alert-threshold", 30, "Days before expiry to warn")
+	metricsAddr := flag.String("metrics-addr", ":8080", "Address to serve Prometheus metrics")
+	flag.Parse()
 
-        // 初始化 Kubernetes 客户端
-        clientset, err := client.InitK8SClient(*kubeconfig)
-        if err != nil {
-                log.Fatalf("Failed to init Kubernetes client: %v", err)
-        }
+	// 初始化 Kubernetes 客户端
+	clientset, err := client.InitK8SClient(*kubeconfig)
+	if err != nil {
+		log.Fatalf("Failed to init Kubernetes client: %v", err)
+	}
+
+	// start metrics server
+	metrics.StartServer(*metricsAddr)
 
 	// 定时检查逻辑
 	ticker := time.NewTicker(24 * time.Hour)
 	defer ticker.Stop()
 
 	// 立即执行一次
-        cert.CheckAllNamespaces(clientset, *alertThreshold)
-        cert.CheckMutatingWebhookCABundles(clientset, *alertThreshold)
+	expiring := cert.CheckAllNamespaces(clientset, *alertThreshold)
+	metrics.SetExpiringCerts(expiring)
+	webhookExpiring := cert.CheckMutatingWebhookCABundles(clientset, *alertThreshold)
+	metrics.SetExpiringWebhookCAs(webhookExpiring)
 
 	// 循环检查
 	for {
 		select {
 		case <-ticker.C:
-                        cert.CheckAllNamespaces(clientset, *alertThreshold)
-                        cert.CheckMutatingWebhookCABundles(clientset, *alertThreshold)
+			expiring := cert.CheckAllNamespaces(clientset, *alertThreshold)
+			metrics.SetExpiringCerts(expiring)
+			webhookExpiring := cert.CheckMutatingWebhookCABundles(clientset, *alertThreshold)
+			metrics.SetExpiringWebhookCAs(webhookExpiring)
 		}
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+var (
+	expiringCerts      int64
+	expiringWebhookCAs int64
+)
+
+// SetExpiringCerts sets the number of expiring TLS secrets.
+func SetExpiringCerts(n int) {
+	atomic.StoreInt64(&expiringCerts, int64(n))
+}
+
+// SetExpiringWebhookCAs sets the number of expiring webhook CA bundles.
+func SetExpiringWebhookCAs(n int) {
+	atomic.StoreInt64(&expiringWebhookCAs, int64(n))
+}
+
+// StartServer starts an HTTP server exposing metrics at the given address.
+func StartServer(addr string) {
+	http.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		fmt.Fprintf(w, "tls_expiring_certs_total %d\n", atomic.LoadInt64(&expiringCerts))
+		fmt.Fprintf(w, "tls_expiring_webhook_ca_total %d\n", atomic.LoadInt64(&expiringWebhookCAs))
+	})
+	go func() {
+		if err := http.ListenAndServe(addr, nil); err != nil {
+			// errors only logged
+			fmt.Printf("metrics server error: %v\n", err)
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- add metrics package and start HTTP metrics server
- update cert check functions to return counts
- serve metrics endpoint for Prometheus to scrape

## Testing
- `go vet ./...` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_6886f4dd62ac83268c44c8df9b1d24be