### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.idea
+*.md
+*.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.24 AS builder
+WORKDIR /src
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source
+COPY . .
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o cert-tls-check main.go
+
+FROM gcr.io/distroless/static
+COPY --from=builder /src/cert-tls-check /cert-tls-check
+USER nonroot:nonroot
+ENTRYPOINT ["/cert-tls-check"]


### PR DESCRIPTION
## Summary
- create multi-stage Dockerfile for building the cert-tls-check utility
- add `.dockerignore`

## Testing
- `go build ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68898a3757e08326a2049c4f7c7af3e4